### PR TITLE
updated early stopping condition

### DIFF
--- a/ransac.py
+++ b/ransac.py
@@ -21,7 +21,7 @@ def run_ransac(data, estimate, is_inlier, sample_size, goal_inliers, max_iterati
         if ic > best_ic:
             best_ic = ic
             best_model = m
-            if ic > goal_inliers and stop_at_goal:
+            if ic >= goal_inliers and stop_at_goal:
                 break
     print('took iterations:', i+1, 'best model:', best_model, 'explains:', best_ic)
     return best_model, best_ic


### PR DESCRIPTION
ransac now stops as soon as the inlier count is greater _or equal_ than the specified number of goal inliers to keep it from always running for max iterations in case goal_inliers == num_samples